### PR TITLE
Adjust volume on `AudioContext` instead of on `<audio />`

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -7,7 +7,7 @@
   {
     "name": "js:eager",
     "path": "dist/assets/index-*.js",
-    "limit": "86 kB"
+    "limit": "87 kB"
   },
   {
     "name": "js:lazy",


### PR DESCRIPTION
Seems like safari ignores `.muted` and `.volume` on `<audio />` when it's used as a source audio node